### PR TITLE
Fix import cleanup

### DIFF
--- a/ragtool.py
+++ b/ragtool.py
@@ -9,7 +9,6 @@ import argparse
 import psycopg2
 import json
 import sys
-from pprint import pprint
 
 from langchain_openai import OpenAIEmbeddings, ChatOpenAI
 from langchain_community.document_loaders import DirectoryLoader


### PR DESCRIPTION
## Summary
- remove unused pprint import from ragtool.py

## Testing
- `python3 -m py_compile ragtool.py`


------
https://chatgpt.com/codex/tasks/task_e_68405fa3d2c8832f83acd2131f8c7876